### PR TITLE
chore: replace w/ with "with"

### DIFF
--- a/metadata/templateChoices.json
+++ b/metadata/templateChoices.json
@@ -1,13 +1,12 @@
 [
         {
-		"title": "Typescript w/ sern cli & ESM",
+		"title": "Typescript with sern cli & ESM",
 		"value": "ts+cli"
 	},
         {
-		"title": "Javascript w/ sern cli & ESM",
+		"title": "Javascript with sern cli & ESM",
 		"value": "js+cli"
 	},
-
         {
 		"title": "Typescript",
 		"value": "ts"


### PR DESCRIPTION
sern gui replaces the word "with" with the localized string, so the (unexpected! :laughing:) changes to the template list looks like this:
### turkish
![image](https://github.com/sern-handler/create-bot/assets/66965250/a62a30ab-1412-4b40-bc0d-5f317cf97d68)
### spanish
![image](https://github.com/sern-handler/create-bot/assets/66965250/f717360c-afe6-4d11-9e1e-1d013803f4f9)
(should we also add localization to &?)
